### PR TITLE
Use official Ookla speedtest CLI app

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,5 @@
 INFLUXDB_DB=speedtest
 INFLUXDB_USERNAME=influx
 INFLUXDB_PASSWORD=influx
-GF_SERVER_ROOT_URL=http://localhost
+SERVER_HOSTNAME=speedtest.example.com
+GF_SERVER_ROOT_URL=https://${SERVER_HOSTNAME}

--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@ Docker starts the following services
 * influxdb
     * store for our speed test results
 * speedtester
-    * schedules a cron job for running a speed test using the [speedtest.net cli][6] every five minutes and appends the results to a csv file
+    * schedules a cron job for running a speed test using the official [speedtest.net cli][6] every five minutes to JSON log files
     * you can change the specified server and interval in the corresponding [Dockerfile][7]
 * telegraf
-    * reads the tail of the csv file with the results and sends them to influxdb
+    * reads the JSON logs with the results and sends them to influxdb
 * grafana
     * visualises our results on a simple preconfigured dashboard
     * default credentials are admin:admin

--- a/docker-compose.override.yaml
+++ b/docker-compose.override.yaml
@@ -1,0 +1,16 @@
+version: '3'
+services: 
+    grafana:
+        networks:
+            - web
+        labels:
+            - traefik.http.routers.speedtest.rule=Host(`${SERVER_HOSTNAME}`)
+            - traefik.http.routers.speedtest.tls=true
+            - traefik.http.routers.speedtest.tls.certresolver=le
+            - traefik.http.services.speedtest.loadbalancer.server.port=3000
+            - traefik.docker.network=web
+            - traefik.http.routers.speedtest.entrypoints=websecure
+
+networks:
+    web:
+        external: true

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -10,12 +10,16 @@ services:
             - INFLUXDB_DB=${INFLUXDB_DB}
             - INFLUXDB_ADMIN_USER=${INFLUXDB_USERNAME}
             - INFLUXDB_ADMIN_PASSWORD=${INFLUXDB_PASSWORD}
+        networks:
+            - speedtest
     speedtester:
         build: 'speedtest/.'
         volumes:
             - speedtest-storage:/usr/speedtest
         depends_on: 
             - "influxdb"
+        networks:
+            - speedtest
     telegraf:
         build: 'telegraf/.'
         volumes:
@@ -23,6 +27,8 @@ services:
             - ./telegraf/telegraf.conf:/etc/telegraf/telegraf.conf
         depends_on: 
             - "influxdb"
+        networks:
+            - speedtest
     grafana:
         build: 'grafana/.'
         ports:
@@ -31,6 +37,12 @@ services:
             - grafana-storage:/var/lib/grafana
         environment:
             - GF_SERVER_ROOT_URL=${GF_SERVER_ROOT_URL}
+        networks:
+            - speedtest
+
+networks:
+    speedtest:
+
 volumes:
     influxdb-storage:
     speedtest-storage:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -15,7 +15,7 @@ services:
     speedtester:
         build: 'speedtest/.'
         volumes:
-            - speedtest-storage:/usr/speedtest
+            - speedtest-storage:/var/log/speedtest
         depends_on: 
             - "influxdb"
         networks:
@@ -23,7 +23,7 @@ services:
     telegraf:
         build: 'telegraf/.'
         volumes:
-            - speedtest-storage:/usr/speedtest
+            - speedtest-storage:/var/log/speedtest
             - ./telegraf/telegraf.conf:/etc/telegraf/telegraf.conf
         depends_on: 
             - "influxdb"

--- a/grafana/dashboards/speedtest.json
+++ b/grafana/dashboards/speedtest.json
@@ -2,7 +2,6 @@
   "annotations": {
     "list": [
       {
-        "$$hashKey": "object:60",
         "builtIn": 1,
         "datasource": "-- Grafana --",
         "enable": true,
@@ -13,11 +12,10 @@
       }
     ]
   },
-  "description": "with speedtest.net",
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "id": 1,
+  "id": 3,
   "links": [],
   "panels": [
     {
@@ -25,12 +23,12 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "InfluxDB",
+      "datasource": null,
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
-        "h": 10,
-        "w": 24,
+        "h": 9,
+        "w": 12,
         "x": 0,
         "y": 0
       },
@@ -49,7 +47,12 @@
       "linewidth": 1,
       "nullPointMode": "null",
       "options": {
-        "dataLinks": []
+        "dataLinks": [
+          {
+            "title": "",
+            "url": ""
+          }
+        ]
       },
       "percentage": false,
       "pointradius": 2,
@@ -61,30 +64,52 @@
       "steppedLine": false,
       "targets": [
         {
-          "alias": "",
+          "alias": "Download",
           "groupBy": [],
-          "measurement": "tail",
+          "measurement": "file",
           "orderByTime": "ASC",
-          "policy": "default",
-          "query": "SELECT \"Download\", \"Upload\" FROM \"tail\" WHERE $timeFilter",
-          "rawQuery": false,
+          "policy": "autogen",
           "refId": "A",
           "resultFormat": "time_series",
           "select": [
             [
               {
                 "params": [
-                  "Download"
+                  "download_bandwidth"
                 ],
                 "type": "field"
+              },
+              {
+                "params": [
+                  " / 125000"
+                ],
+                "type": "math"
               }
-            ],
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "alias": "Upload",
+          "groupBy": [],
+          "measurement": "file",
+          "orderByTime": "ASC",
+          "policy": "autogen",
+          "refId": "B",
+          "resultFormat": "time_series",
+          "select": [
             [
               {
                 "params": [
-                  "Upload"
+                  "upload_bandwidth"
                 ],
                 "type": "field"
+              },
+              {
+                "params": [
+                  " / 125000"
+                ],
+                "type": "math"
               }
             ]
           ],
@@ -101,7 +126,6 @@
         "sort": 0,
         "value_type": "individual"
       },
-      "transparent": true,
       "type": "graph",
       "xaxis": {
         "buckets": null,
@@ -112,22 +136,22 @@
       },
       "yaxes": [
         {
-          "$$hashKey": "object:111",
-          "format": "decbytes",
-          "label": "Speed",
+          "decimals": null,
+          "format": "Mbits",
+          "label": "",
           "logBase": 1,
-          "max": null,
-          "min": null,
+          "max": "1000",
+          "min": "0",
           "show": true
         },
         {
-          "$$hashKey": "object:112",
-          "format": "short",
-          "label": null,
+          "decimals": null,
+          "format": "Mbits",
+          "label": "",
           "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
+          "max": "1000",
+          "min": "0",
+          "show": false
         }
       ],
       "yaxis": {
@@ -162,9 +186,9 @@
   },
   "timezone": "",
   "title": "Speedtest",
-  "uid": "gD_xRveZz",
+  "uid": "Kkn5okfGz",
   "variables": {
     "list": []
   },
-  "version": 3
+  "version": 1
 }

--- a/speedtest/Dockerfile
+++ b/speedtest/Dockerfile
@@ -1,7 +1,5 @@
-FROM python:3-alpine
-WORKDIR /usr/speedtest
-RUN pip install --no-cache-dir speedtest-cli && \
-    speedtest-cli --csv-header > speedtest-results.csv && \
-    # server 3744 - Nessus GmbH (10G Uplink) (Vienna, Austria)
-    echo "*/5 * * * * speedtest-cli --server 3744 --secure --csv >> /usr/speedtest/speedtest-results.csv" > /etc/crontabs/root
+FROM alpine
+RUN wget -O - https://bintray.com/ookla/download/download_file?file_path=ookla-speedtest-1.0.0-x86_64-linux.tgz | tar x -f - -z -C /usr/local/bin/ && \
+    # server 5025 - AT&T (Cicero, IL)
+    echo "*/15 * * * * /usr/local/bin/speedtest --accept-license -s 5025 -f json > \$(mktemp -u -p /var/log/speedtest XXXXXX).json" > /etc/crontabs/root
 CMD ["crond", "-f", "-d", "8"]

--- a/telegraf/telegraf.conf
+++ b/telegraf/telegraf.conf
@@ -604,34 +604,59 @@
 #                            SERVICE INPUT PLUGINS                            #
 ###############################################################################
 
-
-# Stream a log file, like the tail -f command
-[[inputs.tail]]
-  ## files to tail.
-  ## These accept standard unix glob matching rules, but with the addition of
-  ## ** as a "super asterisk". ie:
-  ##   "/var/log/**.log"  -> recursively find all .log files in /var/log
-  ##   "/var/log/*/*.log" -> find all .log files with a parent dir in /var/log
-  ##   "/var/log/apache.log" -> just tail the apache log file
-  ##
-  ## See https://github.com/gobwas/glob for more examples
-  ##
-  files = ["/usr/speedtest/*.csv"]
-  ## Read file from beginning.
-  from_beginning = true
-  ## Whether file is a named pipe
-  pipe = false
-
-  ## Method used to watch for file updates.  Can be either "inotify" or "poll".
-  # watch_method = "inotify"
-
+[[inputs.file]]
+  files = ["/var/log/speedtest/*.json"]
   ## Data format to consume.
   ## Each data format has its own unique set of configuration options, read
   ## more about them here:
   ## https://github.com/influxdata/telegraf/blob/master/docs/DATA_FORMATS_INPUT.md
-  data_format = "csv"
-  csv_header_row_count = 1
-  csv_column_names = ['Server ID','Sponsor','Server Name','Timestamp','Distance','Ping','Download','Upload','Share','IP Address']
-  csv_timestamp_column = "Timestamp"
-  csv_timestamp_format = "2006-01-02T15:04:05Z07:00"
+  data_format = "json"
 
+  ## When strict is true and a JSON array is being parsed, all objects within the
+  ## array must be valid
+  json_strict = true
+
+  ## Query is a GJSON path that specifies a specific chunk of JSON to be
+  ## parsed, if not specified the whole document will be parsed.
+  ##
+  ## GJSON query paths are described here:
+  ##   https://github.com/tidwall/gjson/tree/v1.3.0#path-syntax
+  json_query = ""
+
+  ## Tag keys is an array of keys that should be added as tags.  Matching keys
+  ## are no longer saved as fields. Supports wildcard glob matching.
+  tag_keys = []
+
+  ## Array of glob pattern strings or booleans keys that should be added as string fields.
+  json_string_fields = ["server_name", "server_location", "isp"]
+
+  ## Name key is the key to use as the measurement name.
+  json_name_key = ""
+
+  ## Time key is the key containing the time that should be used to create the
+  ## metric.
+  json_time_key = "timestamp"
+
+  ## Time format is the time layout that should be used to interpret the json_time_key.
+  ## The time must be `unix`, `unix_ms`, `unix_us`, `unix_ns`, or a time in the
+  ## "reference time".  To define a different format, arrange the values from
+  ## the "reference time" in the example to match the format you will be
+  ## using.  For more information on the "reference time", visit
+  ## https://golang.org/pkg/time/#Time.Format
+  ##   ex: json_time_format = "Mon Jan 2 15:04:05 -0700 MST 2006"
+  ##       json_time_format = "2006-01-02T15:04:05Z07:00"
+  ##       json_time_format = "01/02/2006 15:04:05"
+  ##       json_time_format = "unix"
+  ##       json_time_format = "unix_ms"
+  json_time_format = "2006-01-02T15:04:05Z"
+
+  ## Timezone allows you to provide an override for timestamps that
+  ## don't already include an offset
+  ## e.g. 04/06/2016 12:41:45
+  ##
+  ## Default: "" which renders UTC
+  ## Options are as follows:
+  ##   1. Local               -- interpret based on machine localtime
+  ##   2. "America/New_York"  -- Unix TZ values like those found in https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+  ##   3. UTC                 -- or blank/unspecified, will return timestamp in UTC
+  json_timezone = ""


### PR DESCRIPTION
Thanks for putting this together, very helpful!
I found the old python-based speedtest-cli app to be very inconsistent, machine speed dependent, etc.
Switching to the official speedtest CLI app from Ookla results in more reliable speed measurements, consistent with the official gui app.
I had to switch to JSON log format to preserve timestamps which required changes across a few containers. 

Cheers,